### PR TITLE
fix: externalID-Zuordnung im CSV-Header korrigiert

### DIFF
--- a/classes/class.ilImsmExportPlugin.php
+++ b/classes/class.ilImsmExportPlugin.php
@@ -2,7 +2,7 @@
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
 require_once(__DIR__ . '/class.ilImsmExportHelper.php');
-
+require_once(__DIR__ . '/class.ilImsmExportConfig.php');
 /**
  * Abstract parent class for all event hook plugin classes.
  * @author Michael Jansen <mjansen@databay.de>

--- a/classes/class.ilImsmExportPlugin.php
+++ b/classes/class.ilImsmExportPlugin.php
@@ -60,17 +60,17 @@ class ilImsmExportPlugin extends ilTestExportPlugin
         $config = $this->getConfig();
         $data = $this->getTest()->getCompleteEvaluationData(true);
         $titles = $this->getTest()->getQuestionTitlesAndIndexes();
-        $orderedIds = $this->getTest()->getQuestions();
-        asort($orderedIds);
 
+        // $positions aus $titles aufbauen (definierte Testreihenfolge).
+        // asort() auf getQuestions() sortierte nach Question-ID statt Testsequenz.
         $positions = array();
         $pos = 0;
         $row = 0;
-        foreach ($orderedIds as $oid) {
-            $question = assQuestion::_instantiateQuestion($oid);
+        foreach ($titles as $aid => $title) {
+            $question = assQuestion::_instantiateQuestion($aid);
 
             if ($this->isQuestionTypeValid($question->getQuestionType())) {
-                $positions[$oid] = $pos;
+                $positions[$aid] = $pos;
                 $pos++;
             }
         }


### PR DESCRIPTION
$positions aus $titles aufbauen (Testreihenfolge) statt asort() auf getQuestions() (Question-ID) @fneumann bitte gegenprüfen